### PR TITLE
Python wrapping, compiler warning fix and enabling extensions on OSX again.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,25 +4,34 @@
 # Description: vtkMultiVolRen demo
 #
 # Author: xXx <xXX>, (C) 2010
+# Extended by: Berend Klein Haneveld <berendkleinhaneveld@gmail.com>, (C) 2013
 #
 # Copyright: See COPYING file that comes with this distribution
 #==============================================================================
 
-project (vtkGPUMultiVolumeRenderDemo)
-
-
-set(KIT vtkGPUMultiVolumeRenderDemo)
-
-set(CMAKE_XCODE_ATTRIBUTE_GCC_VERSION "4.2")
-
-IF(POLICY CMP0017) 
-  CMAKE_POLICY(SET CMP0017 NEW)
-ENDIF(POLICY CMP0017)
+# Define the project
+PROJECT(vtkGPUMultiVolumeRender)
+SET(KIT vtkGPUMultiVolumeRenderDemo)
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6.4)
 
-FIND_PACKAGE( VTK 5.8 REQUIRED)
-INCLUDE(${VTK_USE_FILE})
+IF(POLICY CMP0017)
+  CMAKE_POLICY(SET CMP0017 NEW)
+ENDIF(POLICY CMP0017)
+
+# On some platforms (OSX) this may not be defined, so search for it
+IF(NOT DEFINED CMAKE_INSTALL_NAME_TOOL)
+  FIND_PROGRAM(CMAKE_INSTALL_NAME_TOOL install_name_tool)
+ENDIF(NOT DEFINED CMAKE_INSTALL_NAME_TOOL)
+
+# Find VTK
+FIND_PACKAGE(VTK 5.8 REQUIRED)
+IF(VTK_FOUND)
+  INCLUDE(${VTK_USE_FILE})
+ELSE(VTK_FOUND)
+  MESSAGE(FATAL_ERROR
+    "Cannot build the executable without VTK. Please set the VTK_DIR")
+ENDIF(VTK_FOUND)
 
 #-----------------------------------------------------------------------------
 # Configure OpenGL support (copied from VTK main CMakeLists.txt).
@@ -43,33 +52,33 @@ IF(APPLE AND VTK_USE_X)
 ENDIF(APPLE AND VTK_USE_X)
 FIND_PACKAGE(OpenGL)
 
+# Need to include class headers and the configuration header.
+INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR})
+INCLUDE_DIRECTORIES(${PROJECT_BINARY_DIR})
+INCLUDE_DIRECTORIES(${OPENGL_INCLUDE_DIR})
 
-INCLUDE_DIRECTORIES(
-  ${OPENGL_INCLUDE_DIR}
-)
-
-
-SET(${KIT}_HDRS
-  ${${KIT}_HDRS}
+SET(HEADERS 
   vtkGPUMultiVolumeRayCastMapper.h
   vtkOpenGLGPUMultiVolumeRayCastMapper.h
 )
 
-SET(${KIT}_SRCS
-  ${${KIT}_SRCS}
+SET(SOURCES 
   vtkGPUMultiVolumeRayCastMapper.cxx
   vtkOpenGLGPUMultiVolumeRayCastMapper.cxx
-  ${KIT}.cxx 
 )
 
-set(KIT_GLSL_SRCS
-   vtkGPUMultiVolumeRayCastMapper_CompositeFS
-   vtkGPUMultiVolumeRayCastMapper_OneComponentFS
-   vtkGPUMultiVolumeRayCastMapper_FourComponentsFS
-   vtkGPUMultiVolumeRayCastMapper_NoShadeFS
-   vtkGPUMultiVolumeRayCastMapper_ShadeFS
+SET(ALL_SOURCES
+  ${KIT}.cxx
+  ${SOURCES}
 )
 
+SET(GLSL_SOURCES
+  vtkGPUMultiVolumeRayCastMapper_CompositeFS
+  vtkGPUMultiVolumeRayCastMapper_OneComponentFS
+  vtkGPUMultiVolumeRayCastMapper_FourComponentsFS
+  vtkGPUMultiVolumeRayCastMapper_NoShadeFS
+  vtkGPUMultiVolumeRayCastMapper_ShadeFS
+)
 
 # -----------------------------------------------------------------------------
 # Create custom commands to encode each glsl file into a C string literal
@@ -77,36 +86,145 @@ set(KIT_GLSL_SRCS
 # -----------------------------------------------------------------------------
 
 # Needs vtkEncodeString, VTK_ENCODESTRING_EXE 
-# should work ...  
+# should work ...
 # VTK_VOLUMERENDERING_EXPORT is the flag associated to the library, should be adapted
-MESSAGE("PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}")
-foreach(file ${KIT_GLSL_SRCS})
+# MESSAGE("PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}")
+FOREACH(file ${GLSL_SOURCES})
   ## TODO
-  set(src  ${PROJECT_SOURCE_DIR}/GLSL/${file}.glsl)
-  set(res  ${CMAKE_CURRENT_BINARY_DIR}/${file}.cxx)
-  set(resh ${CMAKE_CURRENT_BINARY_DIR}/${file}.h)
-  add_custom_command(
+  SET(src  ${PROJECT_SOURCE_DIR}/GLSL/${file}.glsl)
+  SET(res  ${CMAKE_CURRENT_BINARY_DIR}/${file}.cxx)
+  SET(resh ${CMAKE_CURRENT_BINARY_DIR}/${file}.h)
+  ADD_CUSTOM_COMMAND(
     OUTPUT ${res} ${resh}
     DEPENDS ${src} vtkEncodeString
     COMMAND ${VTK_ENCODESTRING_EXE}
     ARGS ${res} ${src} ${file} --build-header VTK_VOLUMERENDERING_EXPORT vtkSystemIncludes.h
-    )
-  set(Kit_EXTRA_SRCS ${Kit_EXTRA_SRCS} ${res})
-endforeach(file)
+  )
+  SET(KIT_EXTRA_SRCS ${KIT_EXTRA_SRCS} ${res})
+ENDFOREACH(file)
 
+# Give user option of building shared or static libraries.  Default to
+# the choice made for VTK.
+OPTION(BUILD_SHARED_LIBS 
+  "Build with shared libraries."
+  ${VTK_BUILD_SHARED_LIBS}
+)
 
+# Set VTKLOCAL_BUILD_SHARED_LIBS to 1 or 0 for use in creating the
+# configuration header.
+IF(BUILD_SHARED_LIBS)
+  SET(VTKLOCAL_BUILD_SHARED_LIBS_CONFIG 1)
+ELSE(BUILD_SHARED_LIBS)
+  SET(VTKLOCAL_BUILD_SHARED_LIBS_CONFIG 0)
+ENDIF(BUILD_SHARED_LIBS)
+
+# List the kits from VTK that are needed by this project.
+SET(VTK_LOCAL_LIBS
+  vtkIO
+  vtkRendering
+  vtkVolumeRendering
+  vtkWidgets
+)
+
+# Hide warnings about using deprecated function calls
 IF(APPLE)
-  SET(EXECUTABLE_FLAG MACOSX_BUNDLE)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated")
 ENDIF(APPLE)
 
-ADD_EXECUTABLE(${KIT} ${EXECUTABLE_FLAG} 
-  ${${KIT}_SRCS}  ${Kit_EXTRA_SRCS})
+# If this is a build tree, provide an option for putting this
+# project's executables and libraries in with VTK's.
+IF(EXISTS ${VTK_DIR}/bin)
+  OPTION(USE_VTK_OUTPUT_PATHS
+    "Use VTK's output directory for this project's executables and libraries."
+    OFF)
+  MARK_AS_ADVANCED(USE_VTK_OUTPUT_PATHS)
+  IF(USE_VTK_OUTPUT_PATHS)
+    SET(LIBRARY_OUTPUT_PATH ${VTK_DIR}/bin)
+    SET(EXECUTABLE_OUTPUT_PATH ${VTK_DIR}/bin)
+  ENDIF(USE_VTK_OUTPUT_PATHS)
+ENDIF(EXISTS ${VTK_DIR}/bin)
 
-TARGET_LINK_LIBRARIES(${KIT} 
-  vtkRendering 
-  vtkIO 
-  vtkVolumeRendering 
-  vtkWidgets
+# Create the library.
+ADD_LIBRARY(${PROJECT_NAME} 
+  ${HEADERS}
+  ${SOURCES}
+  ${GLSL_SOURCES}
+)
+
+TARGET_LINK_LIBRARIES(${PROJECT_NAME}
+  ${VTK_LOCAL_LIBS}
   ${OPENGL_gl_LIBRARY}
- )
+)
 
+# Give the user the option to build the demo as an app
+IF(APPLE)
+  OPTION(BUILD_DEMO_AS_APP
+    "Build the demo as an app bundle."
+    OFF
+  )
+  IF(BUILD_DEMO_AS_APP)
+    SET(EXECUTABLE_FLAG MACOSX_BUNDLE)
+  ENDIF(BUILD_DEMO_AS_APP)
+ENDIF(APPLE)
+
+# Provide the user with the option to build a demo app
+# Default is ON
+OPTION(BUILD_DEMO
+  "Build a demo application."
+  ON
+)
+
+IF(BUILD_DEMO)
+  # Create the demo
+  ADD_EXECUTABLE(${KIT}
+    ${EXECUTABLE_FLAG} 
+    ${ALL_SOURCES}
+    ${KIT_EXTRA_SRCS}
+  )
+
+  TARGET_LINK_LIBRARIES(${KIT}
+    ${VTK_LOCAL_LIBS}
+    ${OPENGL_gl_LIBRARY}
+  )
+ENDIF(BUILD_DEMO)
+
+# Give the user the option of wrapping the library in Python
+OPTION(WRAP_PYTHON 
+  "Wrap the library in Python."
+  ${VTK_WRAP_PYTHON}
+)
+
+# Create Python wrappers if VTK is wrapped in Python.
+IF(WRAP_PYTHON AND VTK_WRAP_PYTHON)
+  SET(VTK_WRAP_PYTHON_FIND_LIBS ON)
+  INCLUDE(${VTK_CMAKE_DIR}/vtkWrapPython.cmake)
+  INCLUDE_DIRECTORIES("${PYTHON_INCLUDE_PATH}")
+  VTK_WRAP_PYTHON3(${PROJECT_NAME}Python 
+    VTK_LOCAL_PYTHON_SRCS
+    "${SOURCES}"
+  )
+  ADD_LIBRARY(${PROJECT_NAME}PythonD 
+    ${VTK_LOCAL_PYTHON_SRCS}
+  )
+  ADD_LIBRARY(${PROJECT_NAME}Python 
+    MODULE
+    ${PROJECT_NAME}PythonInit.cxx
+  )
+  TARGET_LINK_LIBRARIES(${PROJECT_NAME}PythonD 
+    ${VTK_LOCAL_LIBS}
+  	${PROJECT_NAME}
+  )
+  FOREACH(c ${VTK_LOCAL_LIBS})
+    TARGET_LINK_LIBRARIES(${PROJECT_NAME}PythonD ${c}PythonD)
+  ENDFOREACH(c)
+  TARGET_LINK_LIBRARIES(${PROJECT_NAME}Python 
+  	${PROJECT_NAME}PythonD
+  )
+  
+  # Python extension modules on Windows must have the extension ".pyd"
+  # instead of ".dll" as of Python 2.5.  Older python versions do support
+  # this suffix.
+  IF(WIN32 AND NOT CYGWIN)
+    SET_TARGET_PROPERTIES(${PROJECT_NAME}Python PROPERTIES SUFFIX ".pyd")
+  ENDIF(WIN32 AND NOT CYGWIN)    
+ENDIF(WRAP_PYTHON AND VTK_WRAP_PYTHON)

--- a/vtkGPUMultiVolumeRayCastMapper.h
+++ b/vtkGPUMultiVolumeRayCastMapper.h
@@ -41,7 +41,8 @@ public:
   vtkTypeMacro(vtkGPUMultiVolumeRayCastMapper,vtkVolumeMapper);
   void PrintSelf( ostream& os, vtkIndent indent );
 
-  // Define the Input for both datasets 
+  // Define the Input for both datasets
+  using vtkVolumeMapper::SetInput;
   void SetInput( int port, vtkImageData *input );
   void SetInput( int port, vtkDataSet *genericInput );
   vtkImageData * GetInput( int port=0);

--- a/vtkOpenGLGPUMultiVolumeRayCastMapper.cxx
+++ b/vtkOpenGLGPUMultiVolumeRayCastMapper.cxx
@@ -6274,7 +6274,8 @@ int vtkOpenGLGPUMultiVolumeRayCastMapper::RenderSubVolume(vtkRenderer *ren,
           this->ClipBoundingBox(ren,blocks[k].Bounds,volume);
 
           // Adds texture coordinate transform to shader
-          vtkMatrix4x4* mat = TextureCoord_1to2->GetMatrix();
+          vtkMatrix4x4* mat = vtkMatrix4x4::New();
+          mat->DeepCopy(TextureCoord_1to2->GetMatrix());
           mat->Transpose();
           // prepare matrix for shader
           GLfloat matrix_TextureCoord_1to2[16];   
@@ -6288,7 +6289,7 @@ int vtkOpenGLGPUMultiVolumeRayCastMapper::RenderSubVolume(vtkRenderer *ren,
           v->SetUniformMatrix("P1toP2",4,4,matrix_TextureCoord_1to2);
 
           // Add inverse matrix
-          mat = TextureCoord_1to2->GetMatrix();
+          mat->DeepCopy(TextureCoord_1to2->GetMatrix());
           mat->Invert();
           mat->Transpose();
           // prepare matrix for shader
@@ -6299,6 +6300,7 @@ int vtkOpenGLGPUMultiVolumeRayCastMapper::RenderSubVolume(vtkRenderer *ren,
                 static_cast<GLfloat>(mat->Element[c][r]);
             }
           }
+          mat->Delete();
           //vtkUniformVariables *v=this->Program->GetUniformVariables();
           v->SetUniformMatrix("P2toP1",4,4,matrix_TextureCoord_2to1);
 
@@ -6441,7 +6443,8 @@ int vtkOpenGLGPUMultiVolumeRayCastMapper::RenderSubVolume(vtkRenderer *ren,
   this->ClipBoundingBox(ren,bounds,volume);
   
     // Adds texture coordinate transform to shader
-    vtkMatrix4x4* mat = TextureCoord_1to2->GetMatrix();
+    vtkMatrix4x4* mat = vtkMatrix4x4::New();
+    mat->DeepCopy(TextureCoord_1to2->GetMatrix());
     mat->Transpose();
     // prepare matrix for shader
     GLfloat matrix_TextureCoord_1to2[16];   
@@ -6455,7 +6458,7 @@ int vtkOpenGLGPUMultiVolumeRayCastMapper::RenderSubVolume(vtkRenderer *ren,
     v->SetUniformMatrix("P1toP2",4,4,matrix_TextureCoord_1to2);
 
     // Add inverse matrix
-    mat = TextureCoord_1to2->GetMatrix();
+    mat->DeepCopy(TextureCoord_1to2->GetMatrix());
     mat->Invert();
     mat->Transpose();
     // prepare matrix for shader
@@ -6466,6 +6469,7 @@ int vtkOpenGLGPUMultiVolumeRayCastMapper::RenderSubVolume(vtkRenderer *ren,
           static_cast<GLfloat>(mat->Element[c][r]);
       }
     }
+    mat->Delete();
     //vtkUniformVariables *v=this->Program->GetUniformVariables();
     v->SetUniformMatrix("P2toP1",4,4,matrix_TextureCoord_2to1);
 

--- a/vtkOpenGLGPUMultiVolumeRayCastMapper.cxx
+++ b/vtkOpenGLGPUMultiVolumeRayCastMapper.cxx
@@ -3526,11 +3526,12 @@ void vtkOpenGLGPUMultiVolumeRayCastMapper::ClipBoundingBox(vtkRenderer *ren,
 {
   // Pass camera through inverse volume matrix
   // so that we are in the same coordinate system
-  vol->GetMatrix( this->InvVolumeMatrix );
+  this->InvVolumeMatrix->DeepCopy(vol->GetMatrix());
   this->InvVolumeMatrix->Invert();
   // Normals should be transformed using the transpose of the
   // invert of InvVolumeMatrix.
-  vtkMatrix4x4::Transpose(vol->GetMatrix(),this->TempMatrix[0]);
+  this->TempMatrix[0]->DeepCopy(vol->GetMatrix());
+  this->TempMatrix[0]->Transpose();
 
   if(this->BoxSource==0)
     {
@@ -5408,7 +5409,7 @@ void vtkOpenGLGPUMultiVolumeRayCastMapper::RenderRegions(vtkRenderer *ren,
   
   // Pass camera through inverse volume matrix
   // so that we are in the same coordinate system
-  vol->GetMatrix( this->InvVolumeMatrix );
+  this->InvVolumeMatrix->DeepCopy(vol->GetMatrix());
   camPos[3] = 1.0;
   this->InvVolumeMatrix->Invert();
   this->InvVolumeMatrix->MultiplyPoint( camPos, camPos );
@@ -5946,7 +5947,7 @@ int vtkOpenGLGPUMultiVolumeRayCastMapper::RenderSubVolume(vtkRenderer *ren,
         double camPos[4];
         vtkCamera *cam = ren->GetActiveCamera();
         cam->GetPosition(camPos);
-        volume->GetMatrix( this->InvVolumeMatrix );
+        this->InvVolumeMatrix->DeepCopy(volume->GetMatrix());
         camPos[3] = 1.0;
         this->InvVolumeMatrix->Invert();
         this->InvVolumeMatrix->MultiplyPoint( camPos, camPos );

--- a/vtkOpenGLGPUMultiVolumeRayCastMapper.cxx
+++ b/vtkOpenGLGPUMultiVolumeRayCastMapper.cxx
@@ -2168,7 +2168,7 @@ void vtkOpenGLGPUMultiVolumeRayCastMapper::LoadExtensions(
   // It does not work on Apple OS X Snow Leopard with nVidia.
   // There is a bug in the OpenGL driver with an error in the
   // Cg compiler about an infinite loop.
-#ifndef APPLE_SNOW_LEOPARD_BUG
+#ifdef APPLE_SNOW_LEOPARD_BUG
  #ifdef __APPLE__
   this->LoadExtensionsSucceeded=0;
   return;


### PR DESCRIPTION
Hey Karl,

A few weeks ago I found your code from the midas-journal that enables multi-volume rendering in VTK. I took the liberty of adjusting the cmake build system in order to enable Python wrapping so that I can use it in my own project. I've also fixed a compiler warning and I've enabled loading extensions again on OSX so that I actually get some nice renders!

I'm not entirely sure whether I should send this pull request to your repository here, or to the midas-journal repository (or both). What do you think is the best thing to do?

I hope you like the changes!
Cheers,
Berend Klein Haneveld
